### PR TITLE
Make Credentials optional for TaskDispatchEvent.Inputs/Outputs

### DIFF
--- a/src/Messaging/Common/Credentials.cs
+++ b/src/Messaging/Common/Credentials.cs
@@ -9,24 +9,30 @@ namespace Monai.Deploy.Messaging.Common
     public class Credentials
     {
         /// <summary>
-        /// Access key or username of the credentials pair.
+        /// Gets or sets the access key or user name of the credentials pair.
         /// </summary>
         [JsonProperty(PropertyName = "access_key")]
         [Required]
-        public string? AccessKey { get; set; }
+        public string AccessKey { get; set; }
 
         /// <summary>
-        /// Access token or password of the credentials pair.
+        /// Gets or sets the access token or password of the credentials pair.
         /// </summary>
         [JsonProperty(PropertyName = "access_token")]
         [Required]
-        public string? AccessToken { get; set; }
+        public string AccessToken { get; set; }
 
         /// <summary>
-        /// Session token of the credentials pair.
+        /// Gets or sets the session token of the credentials pair.
         /// </summary>
         [JsonProperty(PropertyName = "session_token")]
-        public string? SessionToken { get; set; }
+        public string SessionToken { get; set; }
 
+        public Credentials()
+        {
+            AccessKey = string.Empty;
+            AccessToken = string.Empty;
+            SessionToken = string.Empty;
+        }
     }
 }

--- a/src/Messaging/Common/MessageValidationException.cs
+++ b/src/Messaging/Common/MessageValidationException.cs
@@ -20,7 +20,7 @@ namespace Monai.Deploy.Messaging.Common
 
         private static string FormatMessage(List<ValidationResult> errors)
         {
-            if (errors == null || errors.Count == 0)
+            if (errors is null || errors.Count == 0)
             {
                 return "Invalid message.";
             }

--- a/src/Messaging/Common/Storage.cs
+++ b/src/Messaging/Common/Storage.cs
@@ -14,20 +14,19 @@ namespace Monai.Deploy.Messaging.Common
         /// </summary>
         [JsonProperty(PropertyName = "name")]
         [Required]
-        public string? Name { get; set; }
+        public string Name { get; set; }
 
         /// <summary>
         /// Gets or sets the endpoint of the storage service.
         /// </summary>
         [JsonProperty(PropertyName = "endpoint")]
         [Required]
-        public string? Endpoint { get; set; }
+        public string Endpoint { get; set; }
 
         /// <summary>
         /// Gets or sets credentials for accessing the storage service.
         /// </summary>
         [JsonProperty(PropertyName = "credentials")]
-        [Required]
         public Credentials? Credentials { get; set; }
 
         /// <summary>
@@ -35,19 +34,29 @@ namespace Monai.Deploy.Messaging.Common
         /// </summary>
         [JsonProperty(PropertyName = "bucket")]
         [Required]
-        public string? Bucket { get; set; }
+        public string Bucket { get; set; }
 
         /// <summary>
         /// Gets or sets whether the connection should be secured or not.
         /// </summary>
         [JsonProperty(PropertyName = "secured_connection")]
-        public bool SecuredConnection { get; set; } = false;
+        public bool SecuredConnection { get; set; }
 
         /// <summary>
         /// Gets or sets the optional relative root path to the data.
         /// </summary>
         [JsonProperty(PropertyName = "relative_root_path")]
         [Required]
-        public string? RelativeRootPath { get; set; }
+        public string RelativeRootPath { get; set; }
+
+        public Storage()
+        {
+            Name = string.Empty;
+            Endpoint = string.Empty;
+            Credentials = null;
+            Bucket = string.Empty;
+            SecuredConnection = false;
+            RelativeRootPath = string.Empty;
+        }
     }
 }

--- a/src/Messaging/Events/TaskDispatchEvent.cs
+++ b/src/Messaging/Events/TaskDispatchEvent.cs
@@ -39,11 +39,11 @@ namespace Monai.Deploy.Messaging.Events
         public string CorrelationId { get; set; }
 
         /// <summary>
-        /// Gets or sets the fully qualified assembly name of the task plug-in for the task.
+        /// Gets or sets the type of plug-in the task is associated with.
         /// </summary>
-        [JsonProperty(PropertyName = "task_assembly_name")]
+        [JsonProperty(PropertyName = "type")]
         [Required]
-        public string TaskAssemblyName { get; set; }
+        public string TaskPluginType { get; set; }
 
         /// <summary>
         /// Gets or sets the task execution arguments.
@@ -81,11 +81,11 @@ namespace Monai.Deploy.Messaging.Events
 
         public TaskDispatchEvent()
         {
-            WorkflowId = String.Empty;
-            TaskId = String.Empty;
-            ExecutionId = String.Empty;
-            CorrelationId = String.Empty;
-            TaskAssemblyName = String.Empty;
+            WorkflowId = string.Empty;
+            TaskId = string.Empty;
+            ExecutionId = string.Empty;
+            CorrelationId = string.Empty;
+            TaskPluginType = string.Empty;
             TaskPluginArguments = new Dictionary<string, string>();
             Status = TaskStatus.Unknown;
             Inputs = new List<Storage>();

--- a/src/Messaging/Test/TaskDispatchEventTest.cs
+++ b/src/Messaging/Test/TaskDispatchEventTest.cs
@@ -29,7 +29,7 @@ namespace Monai.Deploy.Messaging.Test
             taskDispatchEvent.CorrelationId = Guid.NewGuid().ToString();
             Assert.Throws<MessageValidationException>(() => taskDispatchEvent.Validate());
 
-            taskDispatchEvent.TaskAssemblyName = Guid.NewGuid().ToString();
+            taskDispatchEvent.TaskPluginType = Guid.NewGuid().ToString();
             Assert.Throws<MessageValidationException>(() => taskDispatchEvent.Validate());
 
             taskDispatchEvent.Inputs = new List<Storage>();
@@ -52,14 +52,7 @@ namespace Monai.Deploy.Messaging.Test
             output.Endpoint = "endpoint";
             Assert.Throws<MessageValidationException>(() => taskDispatchEvent.Validate());
 
-            output.Credentials = new Credentials();
-            Assert.Throws<MessageValidationException>(() => taskDispatchEvent.Validate());
-
-            output.Credentials.AccessToken = "token";
-            Assert.Throws<MessageValidationException>(() => taskDispatchEvent.Validate());
-
-            output.Credentials.AccessKey = "key";
-            Assert.Throws<MessageValidationException>(() => taskDispatchEvent.Validate());
+            // Skip settings credentials for output, this shall not throw given that is not required
 
             output.Bucket = "bucket";
             Assert.Throws<MessageValidationException>(() => taskDispatchEvent.Validate());
@@ -69,14 +62,19 @@ namespace Monai.Deploy.Messaging.Test
 
             input.Name = "name";
             input.Endpoint = "endpoint";
-            input.Credentials = new Credentials
-            {
-                AccessToken = "token",
-                AccessKey = "key"
-            };
             input.Bucket = "bucket";
             input.RelativeRootPath = "path";
+
             var exception = Record.Exception(() => taskDispatchEvent.Validate());
+            Assert.Null(exception);
+
+            // Let's set the credentials for input, this should throw validation exception given that it's no longer null
+            input.Credentials = new Credentials();
+            Assert.Throws<MessageValidationException>(() => taskDispatchEvent.Validate());
+
+            input.Credentials.AccessKey = "key";
+            input.Credentials.AccessToken = "token";
+            exception = Record.Exception(() => taskDispatchEvent.Validate());
             Assert.Null(exception);
         }
     }


### PR DESCRIPTION
### Description

Given that Task Manager will be generating temporary credentials for accessing the buckets, `Credentials` can be optional for `TaskDispatchEvent.Inputs` and `TaskDispatchEvent.Outputs`.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [x] All tests passed locally by running `./src/run-tests-in-docker.sh`.
- [ ] [Documentation comments](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/documentation-comments) included/updated.
- [ ] User guide updated.
- [ ] I have updated the changelog
