### PR TITLE
Intermediate Storage for TaskDispatchEvent

### DIFF
--- a/src/Messaging/Common/Storage.cs
+++ b/src/Messaging/Common/Storage.cs
@@ -6,7 +6,7 @@ using Newtonsoft.Json;
 
 namespace Monai.Deploy.Messaging.Common
 {
-    public class Storage
+    public class Storage : ICloneable
     {
         /// <summary>
         /// Gets or sets the name of the artifact.
@@ -57,6 +57,11 @@ namespace Monai.Deploy.Messaging.Common
             Bucket = string.Empty;
             SecuredConnection = false;
             RelativeRootPath = string.Empty;
+        }
+
+        public object Clone()
+        {
+            return MemberwiseClone();
         }
     }
 }

--- a/src/Messaging/Events/TaskDispatchEvent.cs
+++ b/src/Messaging/Events/TaskDispatchEvent.cs
@@ -74,6 +74,13 @@ namespace Monai.Deploy.Messaging.Events
         public List<Storage> Outputs { get; set; }
 
         /// <summary>
+        /// Gets or sets the intermediate storage information.
+        /// </summary>
+        [JsonProperty(PropertyName = "intermediate_storage")]
+        [Required]
+        public Storage IntermediateStorage { get; set; }
+
+        /// <summary>
         /// Gets or sets any metadata relevant to the task.
         /// </summary>
         [JsonProperty(PropertyName = "metadata")]
@@ -90,6 +97,7 @@ namespace Monai.Deploy.Messaging.Events
             Status = TaskExecutionStatus.Unknown;
             Inputs = new List<Storage>();
             Outputs = new List<Storage>();
+            IntermediateStorage = null!;
             Metadata = new Dictionary<string, object>();
         }
     }

--- a/src/Messaging/Test/TaskCallbackEventTest.cs
+++ b/src/Messaging/Test/TaskCallbackEventTest.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace Monai.Deploy.Messaging.Test
 {
-    public class RunnerCompleteEventTest
+    public class TaskCallbackEventTest
     {
         [Fact(DisplayName = "Validation throws on error")]
         public void ValidationThrowsOnError()

--- a/src/Messaging/Test/TaskDispatchEventTest.cs
+++ b/src/Messaging/Test/TaskDispatchEventTest.cs
@@ -60,6 +60,22 @@ namespace Monai.Deploy.Messaging.Test
             output.RelativeRootPath = "path";
             Assert.Throws<MessageValidationException>(() => taskDispatchEvent.Validate());
 
+            var intermediate = new Storage();
+            taskDispatchEvent.IntermediateStorage = intermediate;
+            Assert.Throws<MessageValidationException>(() => taskDispatchEvent.Validate());
+
+            intermediate.Name = "name";
+            Assert.Throws<MessageValidationException>(() => taskDispatchEvent.Validate());
+
+            intermediate.Endpoint = "endpoint";
+            Assert.Throws<MessageValidationException>(() => taskDispatchEvent.Validate());
+
+            intermediate.Bucket = "bucket";
+            Assert.Throws<MessageValidationException>(() => taskDispatchEvent.Validate());
+
+            intermediate.RelativeRootPath = "path";
+            Assert.Throws<MessageValidationException>(() => taskDispatchEvent.Validate());
+
             input.Name = "name";
             input.Endpoint = "endpoint";
             input.Bucket = "bucket";


### PR DESCRIPTION
### Description
Intermediate storage is always provided in the `TaskDispatchEvent` for the task plugins for storing intermediate data.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] All tests passed locally by running `./src/run-tests-in-docker.sh`.
- [ ] [Documentation comments](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/documentation-comments) included/updated.
- [ ] User guide updated.
- [ ] I have updated the changelog
