### PR TITLE
Throws on error converting events

### DIFF
--- a/src/Messaging/Common/MessageConversionException.cs
+++ b/src/Messaging/Common/MessageConversionException.cs
@@ -1,0 +1,27 @@
+﻿// SPDX-FileCopyrightText: © 2022 MONAI Consortium
+// SPDX-License-Identifier: Apache License 2.0
+//
+using System.Runtime.Serialization;
+
+namespace Monai.Deploy.Messaging.Common
+{
+    [Serializable]
+    public class MessageConversionException : Exception
+    {
+        public MessageConversionException()
+        {
+        }
+
+        public MessageConversionException(string message) : base(message)
+        {
+        }
+
+        public MessageConversionException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
+
+        protected MessageConversionException(SerializationInfo info, StreamingContext context) : base(info, context)
+        {
+        }
+    }
+}

--- a/src/Messaging/Messages/Message.cs
+++ b/src/Messaging/Messages/Message.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache License 2.0
 
 using System.Text;
+using Monai.Deploy.Messaging.Common;
 using Newtonsoft.Json;
 
 namespace Monai.Deploy.Messaging.Messages
@@ -39,9 +40,9 @@ namespace Monai.Deploy.Messaging.Messages
                 var json = Encoding.UTF8.GetString(Body);
                 return JsonConvert.DeserializeObject<T>(json)!;
             }
-            catch
+            catch(Exception ex)
             {
-                return default!;
+                throw new MessageConversionException($"Error converting message to type {typeof(T)}", ex);
             }
         }
 
@@ -54,13 +55,12 @@ namespace Monai.Deploy.Messaging.Messages
         {
             try
             {
-                var json = Encoding.UTF8.GetString(Body);
-                var body = JsonConvert.DeserializeObject<T>(json)!;
+                var body = ConvertTo<T>();
                 return new JsonMessage<T>(body, MessageDescription, MessageId, ApplicationId, CorrelationId, CreationDateTime, DeliveryTag);
             }
-            catch
+            catch (Exception ex)
             {
-                return null!;
+                throw new MessageConversionException($"Error converting message to type {typeof(T)}", ex);
             }
         }
     }

--- a/src/Messaging/Test/JsonMessageTest.cs
+++ b/src/Messaging/Test/JsonMessageTest.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache License 2.0
 
 using System;
+using Monai.Deploy.Messaging.Common;
 using Monai.Deploy.Messaging.Messages;
 using Xunit;
 
@@ -19,19 +20,16 @@ namespace Monai.Deploy.Messaging.Test
 
     public class JsonMessageTest
     {
-        [Fact(DisplayName = "Convert returns null on different type")]
-        public void ConvertsReturnsNull()
+        [Fact(DisplayName = "Convert throws on different type")]
+        public void ConvertsThrowsError()
         {
             var data = new DummyTypeOne { MyProperty = "hello world" };
             var jsonMessage = new JsonMessage<DummyTypeOne>(data, Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), Guid.NewGuid().ToString());
             var message = jsonMessage.ToMessage();
 
 
-            var result = message.ConvertTo<DummyTypeTwo>();
-            Assert.Null(result);
-
-            var jsonMessageResult = message.ConvertToJsonMessage<DummyTypeTwo>();
-            Assert.Null(jsonMessageResult);
+            Assert.Throws<MessageConversionException>(() => message.ConvertTo<DummyTypeTwo>());
+            Assert.Throws<MessageConversionException>(() => message.ConvertToJsonMessage<DummyTypeTwo>());
         }
         [Fact(DisplayName = "Converts JsonMessage to Message")]
         public void ConvertsJsonMessageToMessage()


### PR DESCRIPTION
### Description

Throws `MessageConversionException` on failure to convert any event messages.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [ ] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] All tests passed locally by running `./src/run-tests-in-docker.sh`.
- [ ] [Documentation comments](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/documentation-comments) included/updated.
- [ ] User guide updated.
- [ ] I have updated the changelog
