### PR TITLE
Remove length limit for Identity

### DIFF
--- a/src/Messaging/Events/TaskCallbackEvent.cs
+++ b/src/Messaging/Events/TaskCallbackEvent.cs
@@ -54,7 +54,7 @@ namespace Monai.Deploy.Messaging.Events
         /// Gets or sets the identity provided by the external service.
         /// </summary>
         [JsonProperty(PropertyName = "identity")]
-        [Required, MaxLength(63)]
+        [Required]
         public string Identity { get; set; }
 
         /// <summary>

--- a/src/Messaging/Tests/TaskCallbackEventTest.cs
+++ b/src/Messaging/Tests/TaskCallbackEventTest.cs
@@ -41,9 +41,6 @@ namespace Monai.Deploy.Messaging.Tests
             runnerComplete.CorrelationId = Guid.NewGuid().ToString();
             Assert.Throws<MessageValidationException>(() => runnerComplete.Validate());
 
-            runnerComplete.Identity = "1234567890123456789012345678901234567890123456789012345678901234567890";
-            Assert.Throws<MessageValidationException>(() => runnerComplete.Validate());
-
             runnerComplete.Identity = "123456789012345678901234567890123456789012345678901234567890123";
             var exception = Record.Exception(() => runnerComplete.Validate());
             Assert.Null(exception);


### PR DESCRIPTION
### Description

Removes the max length limit on the `Identity` property to allow other applications, such as Docker, to store an ID with value longer than 63 characters.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] All tests passed locally.
- [ ] [Documentation comments](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/documentation-comments) included/updated.
