### PR TITLE
Remove length limit for Idenity in TaskCallbackEvent

### DIFF
--- a/src/Messaging/Events/TaskCallbackEvent.cs
+++ b/src/Messaging/Events/TaskCallbackEvent.cs
@@ -54,7 +54,7 @@ namespace Monai.Deploy.Messaging.Events
         /// Gets or sets the identity provided by the external service.
         /// </summary>
         [JsonProperty(PropertyName = "identity")]
-        [Required, MaxLength(63)]
+        [Required]
         public string Identity { get; set; }
 
         /// <summary>

--- a/src/Messaging/Tests/TaskCallbackEventTest.cs
+++ b/src/Messaging/Tests/TaskCallbackEventTest.cs
@@ -41,9 +41,6 @@ namespace Monai.Deploy.Messaging.Tests
             runnerComplete.CorrelationId = Guid.NewGuid().ToString();
             Assert.Throws<MessageValidationException>(() => runnerComplete.Validate());
 
-            runnerComplete.Identity = "1234567890123456789012345678901234567890123456789012345678901234567890";
-            Assert.Throws<MessageValidationException>(() => runnerComplete.Validate());
-
             runnerComplete.Identity = "123456789012345678901234567890123456789012345678901234567890123";
             var exception = Record.Exception(() => runnerComplete.Validate());
             Assert.Null(exception);


### PR DESCRIPTION
### Description

Move changes from release/0.1.6 to release/0.1.5
