### PR TITLE
Close channel at the end of health check

### DIFF
--- a/doc/dependency_decisions.yml
+++ b/doc/dependency_decisions.yml
@@ -410,14 +410,14 @@
   - :who: mocsharp
     :why: MIT (https://github.com/TestableIO/System.IO.Abstractions/raw/main/LICENSE)
     :versions:
-    - 17.2.1
+    - 17.2.3
     :when: 2022-08-16 21:39:59.728481602 Z
 - - :approve
   - System.IO.Abstractions.TestingHelpers
   - :who: mocsharp
     :why: MIT (https://github.com/TestableIO/System.IO.Abstractions/raw/main/LICENSE)
     :versions:
-    - 17.2.1
+    - 17.2.3
     :when: 2022-08-16 21:40:00.150566731 Z
 - - :approve
   - System.IO.Compression

--- a/doc/dependency_decisions.yml
+++ b/doc/dependency_decisions.yml
@@ -32,7 +32,7 @@
   - :who: mocsharp
     :why: MIT (https://github.com/dotnet/aspnetcore/raw/main/LICENSE.txt)
     :versions:
-    - 6.0.8
+    - 6.0.9
     :when: 2022-08-29 18:11:22.090772006 Z
 - - :approve
   - Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions
@@ -219,9 +219,9 @@
 - - :approve
   - Microsoft.NET.Test.Sdk
   - :who: mocsharp
-    :why: MIT (https://github.com/microsoft/vstest/raw/v17.3.0/LICENSE)
+    :why: MIT (https://github.com/microsoft/vstest/raw/v17.3.1/LICENSE)
     :versions:
-    - 17.3.0
+    - 17.3.1
     :when: 2022-08-16 21:39:48.253593534 Z
 - - :approve
   - Microsoft.NETCore.Platforms
@@ -410,14 +410,14 @@
   - :who: mocsharp
     :why: MIT (https://github.com/TestableIO/System.IO.Abstractions/raw/main/LICENSE)
     :versions:
-    - 17.1.1
+    - 17.2.1
     :when: 2022-08-16 21:39:59.728481602 Z
 - - :approve
   - System.IO.Abstractions.TestingHelpers
   - :who: mocsharp
     :why: MIT (https://github.com/TestableIO/System.IO.Abstractions/raw/main/LICENSE)
     :versions:
-    - 17.1.1
+    - 17.2.1
     :when: 2022-08-16 21:40:00.150566731 Z
 - - :approve
   - System.IO.Compression

--- a/doc/dependency_decisions.yml
+++ b/doc/dependency_decisions.yml
@@ -25,7 +25,7 @@
   - :who: mocsharp
     :why: MIT (https://github.com/microsoft/vstest/raw/v17.3.0/LICENSE)
     :versions:
-    - 17.3.0
+    - 17.3.1
     :when: 2022-08-16 21:39:37.382080790 Z
 - - :approve
   - Microsoft.Extensions.Diagnostics.HealthChecks
@@ -39,7 +39,7 @@
   - :who: mocsharp
     :why: MIT (https://github.com/dotnet/aspnetcore/raw/main/LICENSE.txt)
     :versions:
-    - 6.0.8
+    - 6.0.9
     :when: 2022-08-29 18:11:22.090772006 Z
 - - :approve
   - Microsoft.Extensions.Configuration
@@ -158,7 +158,7 @@
   - :who: mocsharp
     :why: MIT (https://github.com/dotnet/runtime/raw/main/LICENSE.TXT)
     :versions:
-    - 6.0.1
+    - 6.0.2
     :when: 2022-08-16 21:39:44.471693654 Z
 - - :approve
   - Microsoft.Extensions.Logging.Configuration
@@ -240,16 +240,16 @@
 - - :approve
   - Microsoft.TestPlatform.ObjectModel
   - :who: mocsharp
-    :why: MIT (https://github.com/microsoft/vstest/raw/v17.3.0/LICENSE)
+    :why: MIT (https://github.com/microsoft/vstest/raw/v17.3.1/LICENSE)
     :versions:
-    - 17.3.0
+    - 17.3.1
     :when: 2022-08-16 21:39:49.547958989 Z
 - - :approve
   - Microsoft.TestPlatform.TestHost
   - :who: mocsharp
-    :why: MIT (https://github.com/microsoft/vstest/raw/v17.3.0/LICENSE)
+    :why: MIT (https://github.com/microsoft/vstest/raw/v17.3.1/LICENSE)
     :versions:
-    - 17.3.0
+    - 17.3.1
     :when: 2022-08-16 21:39:49.963749572 Z
 - - :approve
   - Microsoft.Win32.Primitives

--- a/src/Messaging/Monai.Deploy.Messaging.csproj
+++ b/src/Messaging/Monai.Deploy.Messaging.csproj
@@ -81,6 +81,6 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="RabbitMQ.Client" Version="6.4.0" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
-    <PackageReference Include="System.IO.Abstractions" Version="17.2.1" />
+    <PackageReference Include="System.IO.Abstractions" Version="17.2.3" />
   </ItemGroup>
 </Project>

--- a/src/Messaging/Monai.Deploy.Messaging.csproj
+++ b/src/Messaging/Monai.Deploy.Messaging.csproj
@@ -76,11 +76,11 @@
   <ItemGroup>
     <PackageReference Include="Ardalis.GuardClauses" Version="4.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="6.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="6.0.9" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="RabbitMQ.Client" Version="6.4.0" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
-    <PackageReference Include="System.IO.Abstractions" Version="17.1.1" />
+    <PackageReference Include="System.IO.Abstractions" Version="17.2.1" />
   </ItemGroup>
 </Project>

--- a/src/Messaging/Tests/Monai.Deploy.Messaging.Tests.csproj
+++ b/src/Messaging/Tests/Monai.Deploy.Messaging.Tests.csproj
@@ -34,7 +34,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
     <PackageReference Include="Moq" Version="4.18.2" />
-    <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="17.2.1" />
+    <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="17.2.3" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Messaging/Tests/Monai.Deploy.Messaging.Tests.csproj
+++ b/src/Messaging/Tests/Monai.Deploy.Messaging.Tests.csproj
@@ -32,9 +32,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
     <PackageReference Include="Moq" Version="4.18.2" />
-    <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="17.1.1" />
+    <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="17.2.1" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Plugins/RabbitMQ/RabbitMQHealthCheck.cs
+++ b/src/Plugins/RabbitMQ/RabbitMQHealthCheck.cs
@@ -46,14 +46,14 @@ namespace Monai.Deploy.Messaging.RabbitMQ
         {
             try
             {
-                _ = _connectionFactory.CreateChannel(
+                using var channel = _connectionFactory.CreateChannel(
                     _options[ConfigurationKeys.EndPoint],
                     _options[ConfigurationKeys.Username],
                     _options[ConfigurationKeys.Password],
                     _options[ConfigurationKeys.VirtualHost],
                     _options.ContainsKey(ConfigurationKeys.UseSSL) ? _options[ConfigurationKeys.UseSSL] : string.Empty,
                     _options.ContainsKey(ConfigurationKeys.Port) ? _options[ConfigurationKeys.Port] : string.Empty);
-
+                channel.Close();
                 return await Task.FromResult(HealthCheckResult.Healthy()).ConfigureAwait(false);
             }
             catch (Exception ex)

--- a/src/Plugins/RabbitMQ/Tests/Monai.Deploy.Messaging.RabbitMQ.Tests.csproj
+++ b/src/Plugins/RabbitMQ/Tests/Monai.Deploy.Messaging.RabbitMQ.Tests.csproj
@@ -35,9 +35,9 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
     <PackageReference Include="Moq" Version="4.18.2" />
-    <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="17.1.1" />
+    <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="17.2.1" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Plugins/RabbitMQ/Tests/Monai.Deploy.Messaging.RabbitMQ.Tests.csproj
+++ b/src/Plugins/RabbitMQ/Tests/Monai.Deploy.Messaging.RabbitMQ.Tests.csproj
@@ -37,7 +37,7 @@
     <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
     <PackageReference Include="Moq" Version="4.18.2" />
-    <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="17.2.1" />
+    <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="17.2.3" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/third-party-licenses.md
+++ b/third-party-licenses.md
@@ -1217,16 +1217,16 @@ SOFTWARE.
 
 
 <details>
-<summary>Microsoft.NET.Test.Sdk 17.3.0</summary>
+<summary>Microsoft.NET.Test.Sdk 17.3.1</summary>
 
 ## Microsoft.NET.Test.Sdk
 
-- Version: 17.3.0
+- Version: 17.3.1
 - Authors: Microsoft
 - Owners: Microsoft
 - Project URL: https://github.com/microsoft/vstest/
-- Source: [NuGet](https://www.nuget.org/packages/Microsoft.NET.Test.Sdk/17.3.0)
-- License: [MIT](https://github.com/microsoft/vstest/raw/v17.3.0/LICENSE)
+- Source: [NuGet](https://www.nuget.org/packages/Microsoft.NET.Test.Sdk/17.3.1)
+- License: [MIT](https://github.com/microsoft/vstest/raw/v17.3.1/LICENSE)
 
 
 ```
@@ -5034,14 +5034,14 @@ consequential or other damages.
 
 
 <details>
-<summary>System.IO.Abstractions 17.1.1</summary>
+<summary>System.IO.Abstractions 17.2.1</summary>
 
 ## System.IO.Abstractions
 
-- Version: 17.1.1
+- Version: 17.2.1
 - Authors: Tatham Oddie & friends
 - Project URL: https://github.com/TestableIO/System.IO.Abstractions
-- Source: [NuGet](https://www.nuget.org/packages/System.IO.Abstractions/17.1.1)
+- Source: [NuGet](https://www.nuget.org/packages/System.IO.Abstractions/17.2.1)
 - License: [MIT](https://github.com/TestableIO/System.IO.Abstractions/raw/main/LICENSE)
 
 
@@ -5075,14 +5075,14 @@ SOFTWARE.
 
 
 <details>
-<summary>System.IO.Abstractions.TestingHelpers 17.1.1</summary>
+<summary>System.IO.Abstractions.TestingHelpers 17.2.1</summary>
 
 ## System.IO.Abstractions.TestingHelpers
 
-- Version: 17.1.1
+- Version: 17.2.1
 - Authors: Tatham Oddie & friends
 - Project URL: https://github.com/TestableIO/System.IO.Abstractions
-- Source: [NuGet](https://www.nuget.org/packages/System.IO.Abstractions.TestingHelpers/17.1.1)
+- Source: [NuGet](https://www.nuget.org/packages/System.IO.Abstractions.TestingHelpers/17.2.1)
 - License: [MIT](https://github.com/TestableIO/System.IO.Abstractions/raw/main/LICENSE)
 
 

--- a/third-party-licenses.md
+++ b/third-party-licenses.md
@@ -5133,14 +5133,14 @@ consequential or other damages.
 
 
 <details>
-<summary>System.IO.Abstractions 17.2.1</summary>
+<summary>System.IO.Abstractions 17.2.3</summary>
 
 ## System.IO.Abstractions
 
-- Version: 17.2.1
+- Version: 17.2.3
 - Authors: Tatham Oddie & friends
 - Project URL: https://github.com/TestableIO/System.IO.Abstractions
-- Source: [NuGet](https://www.nuget.org/packages/System.IO.Abstractions/17.2.1)
+- Source: [NuGet](https://www.nuget.org/packages/System.IO.Abstractions/17.2.3)
 - License: [MIT](https://github.com/TestableIO/System.IO.Abstractions/raw/main/LICENSE)
 
 
@@ -5174,14 +5174,14 @@ SOFTWARE.
 
 
 <details>
-<summary>System.IO.Abstractions.TestingHelpers 17.2.1</summary>
+<summary>System.IO.Abstractions.TestingHelpers 17.2.3</summary>
 
 ## System.IO.Abstractions.TestingHelpers
 
-- Version: 17.2.1
+- Version: 17.2.3
 - Authors: Tatham Oddie & friends
 - Project URL: https://github.com/TestableIO/System.IO.Abstractions
-- Source: [NuGet](https://www.nuget.org/packages/System.IO.Abstractions.TestingHelpers/17.2.1)
+- Source: [NuGet](https://www.nuget.org/packages/System.IO.Abstractions.TestingHelpers/17.2.3)
 - License: [MIT](https://github.com/TestableIO/System.IO.Abstractions/raw/main/LICENSE)
 
 

--- a/third-party-licenses.md
+++ b/third-party-licenses.md
@@ -1,3 +1,20 @@
+<!-- 
+Copyright 2022 MONAI Consortium
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. 
+-->
+
+
 # Third-Party Licenses
 
 
@@ -154,15 +171,15 @@ SOFTWARE.
 
 
 <details>
-<summary>Microsoft.CodeCoverage 17.3.0</summary>
+<summary>Microsoft.CodeCoverage 17.3.1</summary>
 
 ## Microsoft.CodeCoverage
 
-- Version: 17.3.0
+- Version: 17.3.1
 - Authors: Microsoft
 - Owners: Microsoft
 - Project URL: https://github.com/microsoft/vstest/
-- Source: [NuGet](https://www.nuget.org/packages/Microsoft.CodeCoverage/17.3.0)
+- Source: [NuGet](https://www.nuget.org/packages/Microsoft.CodeCoverage/17.3.1)
 - License: [MIT](https://github.com/microsoft/vstest/raw/v17.3.0/LICENSE)
 
 
@@ -602,6 +619,88 @@ SOFTWARE.
 
 
 <details>
+<summary>Microsoft.Extensions.Diagnostics.HealthChecks 6.0.9</summary>
+
+## Microsoft.Extensions.Diagnostics.HealthChecks
+
+- Version: 6.0.9
+- Authors: Microsoft
+- Project URL: https://asp.net/
+- Source: [NuGet](https://www.nuget.org/packages/Microsoft.Extensions.Diagnostics.HealthChecks/6.0.9)
+- License: [MIT](https://github.com/dotnet/aspnetcore/raw/main/LICENSE.txt)
+
+
+```
+The MIT License (MIT)
+
+Copyright (c) .NET Foundation and Contributors
+
+All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```
+
+</details>
+
+
+<details>
+<summary>Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions 6.0.9</summary>
+
+## Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions
+
+- Version: 6.0.9
+- Authors: Microsoft
+- Project URL: https://asp.net/
+- Source: [NuGet](https://www.nuget.org/packages/Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions/6.0.9)
+- License: [MIT](https://github.com/dotnet/aspnetcore/raw/main/LICENSE.txt)
+
+
+```
+The MIT License (MIT)
+
+Copyright (c) .NET Foundation and Contributors
+
+All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```
+
+</details>
+
+
+<details>
 <summary>Microsoft.Extensions.FileProviders.Abstractions 6.0.0</summary>
 
 ## Microsoft.Extensions.FileProviders.Abstractions
@@ -848,14 +947,14 @@ SOFTWARE.
 
 
 <details>
-<summary>Microsoft.Extensions.Logging.Abstractions 6.0.0</summary>
+<summary>Microsoft.Extensions.Logging.Abstractions 6.0.2</summary>
 
 ## Microsoft.Extensions.Logging.Abstractions
 
-- Version: 6.0.0
+- Version: 6.0.2
 - Authors: Microsoft
 - Project URL: https://dot.net/
-- Source: [NuGet](https://www.nuget.org/packages/Microsoft.Extensions.Logging.Abstractions/6.0.0)
+- Source: [NuGet](https://www.nuget.org/packages/Microsoft.Extensions.Logging.Abstractions/6.0.2)
 - License: [MIT](https://github.com/dotnet/runtime/raw/main/LICENSE.TXT)
 
 
@@ -1655,16 +1754,16 @@ consequential or other damages.
 
 
 <details>
-<summary>Microsoft.TestPlatform.ObjectModel 17.3.0</summary>
+<summary>Microsoft.TestPlatform.ObjectModel 17.3.1</summary>
 
 ## Microsoft.TestPlatform.ObjectModel
 
-- Version: 17.3.0
+- Version: 17.3.1
 - Authors: Microsoft
 - Owners: Microsoft
 - Project URL: https://github.com/microsoft/vstest/
-- Source: [NuGet](https://www.nuget.org/packages/Microsoft.TestPlatform.ObjectModel/17.3.0)
-- License: [MIT](https://github.com/microsoft/vstest/raw/v17.3.0/LICENSE)
+- Source: [NuGet](https://www.nuget.org/packages/Microsoft.TestPlatform.ObjectModel/17.3.1)
+- License: [MIT](https://github.com/microsoft/vstest/raw/v17.3.1/LICENSE)
 
 
 ```
@@ -1693,16 +1792,16 @@ SOFTWARE.
 
 
 <details>
-<summary>Microsoft.TestPlatform.TestHost 17.3.0</summary>
+<summary>Microsoft.TestPlatform.TestHost 17.3.1</summary>
 
 ## Microsoft.TestPlatform.TestHost
 
-- Version: 17.3.0
+- Version: 17.3.1
 - Authors: Microsoft
 - Owners: Microsoft
 - Project URL: https://github.com/microsoft/vstest/
-- Source: [NuGet](https://www.nuget.org/packages/Microsoft.TestPlatform.TestHost/17.3.0)
-- License: [MIT](https://github.com/microsoft/vstest/raw/v17.3.0/LICENSE)
+- Source: [NuGet](https://www.nuget.org/packages/Microsoft.TestPlatform.TestHost/17.3.1)
+- License: [MIT](https://github.com/microsoft/vstest/raw/v17.3.1/LICENSE)
 
 
 ```
@@ -12540,6 +12639,7 @@ corefx/LICENSE.TXT at master · dotnet/corefx · GitHub
 
 
 
+
 Skip to content
 
 
@@ -12548,6 +12648,7 @@ Skip to content
 
 
 
+Toggle navigation
 
 
 
@@ -12558,13 +12659,8 @@ Skip to content
 
 
 
-              Sign up
-            
- 
-
-
- 
-
+            Sign up
+          
 
 
  
@@ -12576,165 +12672,257 @@ Skip to content
 
 
 
-        Product
-        
+
+
+      Product
+      
 
 
 
 
 
-      Features
- 
-
-
-      Mobile
- 
-
-
-      Actions
- 
-
-
-      Codespaces
- 
-
-
-      Copilot
- 
-
-
-      Packages
- 
-
-
-      Security
- 
-
-
-      Code review
- 
-
-
-      Issues
- 
-
-
-      Discussions
- 
-
-
-      Integrations
- 
-
-
-      GitHub Sponsors
- 
-
-
-      Customer stories
- 
 
 
 
 
 
-Team
 
-
-Enterprise
-
-
-
-
-        Explore
-        
+Actions
+        Automate any workflow
+      
 
 
 
 
 
-      Explore GitHub
- 
-Learn and contribute
+
+
+Packages
+        Host and manage packages
+      
+
+
+
+
+
+
+
+Security
+        Find and fix vulnerabilities
+      
+
+
+
+
+
+
+
+Codespaces
+        Instant dev environments
+      
+
+
+
+
+
+
+
+Copilot
+        Write better code with AI
+      
+
+
+
+
+
+
+
+Code review
+        Manage code changes
+      
+
+
+
+
+
+
+
+Issues
+        Plan and track work
+      
+
+
+
+
+
+
+
+Discussions
+        Collaborate outside of code
+      
+
+
+
+Explore
+
+
+      All features
+
+    
+
+
+
+      Documentation
+
+    
+
+
+
+
+
+      GitHub Skills
+
+    
+
+
+
+
+
+      Changelog
+
+    
+
+
+
+
+
+
+
+
+      Solutions
+      
+
+
+
+
+
+By Size
+
+
+      Enterprise
+
+    
+
+
+
+      Teams
+
+    
+
+
+
+      Compare all
+
+    
+
+
+
+By Solution
+
+
+      CI/CD & Automation
+
+    
+
+
+
+
+
+      DevOps
+
+    
+
+
+
+
+
+      DevSecOps
+
+    
+
+
+
+
+
+Case Studies
+
+
+      Customer Stories
+
+    
+
+
+
+      Resources
+
+    
+
+
+
+
+
+
+
+
+      Open Source
+      
+
+
+
+
+
+
+
+
+GitHub Sponsors
+        Fund open source developers
+      
+
+
+
+
+
+
+The ReadME Project
+        GitHub community articles
+      
+
+
+
+Repositories
 
 
       Topics
- 
 
+    
 
-      Collections
- 
 
 
       Trending
- 
+
+    
 
 
-      Skills
- 
 
+      Collections
 
-      GitHub Sponsors
- 
-
-
-      Open source guides
- 
-Connect with others
-
-
-      The ReadME Project
- 
-
-
-      Events
- 
-
-
-      Community forum
- 
-
-
-      GitHub Education
- 
-
-
-      GitHub Stars program
- 
+    
 
 
 
 
 
-Marketplace
-
-
-
-
-        Pricing
-        
-
-
-
-
-
-      Plans
- 
-
-
-      Compare plans
- 
-
-
-      Contact Sales
- 
-
-
-      Education
- 
-
-
-
+Pricing
 
 
 
@@ -12889,12 +13077,13 @@ No suggested jump to results
 
 
 
-            Sign in
-          
+              Sign in
+            
 
 
-            Sign up
-          
+              Sign up
+            
+
 
 
 
@@ -12971,7 +13160,7 @@ Code
 
 
 Pull requests
-6
+3
 
 
 


### PR DESCRIPTION
### Description

After running for a while, the health check API may exhaust all available channels in a RabbitMQ connection.
Fix to close the channel at the end of the check.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [ ] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [x] All tests passed locally.
- [ ] [Documentation comments](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/documentation-comments) included/updated.
