### PR TITLE
fix rabbitmq healthcheck

### DIFF
--- a/src/Plugins/RabbitMQ/Factory/RabbitMqConnectionFactory.cs
+++ b/src/Plugins/RabbitMQ/Factory/RabbitMqConnectionFactory.cs
@@ -54,7 +54,7 @@ namespace Monai.Deploy.Messaging.RabbitMQ
             var key = $"{hostName}{username}{HashPassword(password)}{virtualHost}";
 
             var connection = _connections.AddOrUpdate(key,
-                x => CreatConnection(hostName, username, password, virtualHost, key, useSSL, portNumber),
+                x => CreateConnection(hostName, username, password, virtualHost, key, useSSL, portNumber),
                 (updateKey, updateConnection) =>
                 {
                     // If connection to RMQ is lost and:
@@ -67,7 +67,7 @@ namespace Monai.Deploy.Messaging.RabbitMQ
                     }
                     else
                     {
-                        return CreatConnection(hostName, username, password, virtualHost, key, useSSL, portNumber);
+                        return CreateConnection(hostName, username, password, virtualHost, key, useSSL, portNumber);
                     }
                 });
 
@@ -101,7 +101,7 @@ namespace Monai.Deploy.Messaging.RabbitMQ
             }
         }
 
-        private Lazy<IConnection> CreatConnection(string hostName, string username, string password, string virtualHost, string key, string useSSL, string portNumber)
+        private Lazy<IConnection> CreateConnection(string hostName, string username, string password, string virtualHost, string key, string useSSL, string portNumber)
         {
             if (!bool.TryParse(useSSL, out var sslEnabled))
             {
@@ -129,6 +129,7 @@ namespace Monai.Deploy.Messaging.RabbitMQ
                 Ssl = sslOptions,
                 Port = port,
                 RequestedHeartbeat = TimeSpan.FromSeconds(10),
+                AutomaticRecoveryEnabled = true
             }));
 
             return new Lazy<IConnection>(connectionFactory.Value.CreateConnection);
@@ -139,7 +140,7 @@ namespace Monai.Deploy.Messaging.RabbitMQ
             Guard.Against.NullOrWhiteSpace(password);
             var sha256 = SHA256.Create();
             var hash = sha256.ComputeHash(Encoding.UTF8.GetBytes(password));
-            return hash.Select(x => x.ToString("x2", CultureInfo.InvariantCulture));
+            return string.Join("", hash.Select(x => x.ToString("x2", CultureInfo.InvariantCulture)));
         }
 
         protected virtual void Dispose(bool disposing)

--- a/src/Plugins/RabbitMQ/RabbitMQHealthCheck.cs
+++ b/src/Plugins/RabbitMQ/RabbitMQHealthCheck.cs
@@ -46,14 +46,14 @@ namespace Monai.Deploy.Messaging.RabbitMQ
         {
             try
             {
-                using var channel = _connectionFactory.CreateChannel(
+                var channel = _connectionFactory.CreateChannel(
                     _options[ConfigurationKeys.EndPoint],
                     _options[ConfigurationKeys.Username],
                     _options[ConfigurationKeys.Password],
                     _options[ConfigurationKeys.VirtualHost],
                     _options.ContainsKey(ConfigurationKeys.UseSSL) ? _options[ConfigurationKeys.UseSSL] : string.Empty,
                     _options.ContainsKey(ConfigurationKeys.Port) ? _options[ConfigurationKeys.Port] : string.Empty);
-                channel.Close();
+
                 return await Task.FromResult(HealthCheckResult.Healthy()).ConfigureAwait(false);
             }
             catch (Exception ex)


### PR DESCRIPTION
Signed-off-by: Neil South <neil.south@answerdigital.com>

### Description

Fix to stop Rabbit channel being destroyed on every health check,
added `AutomaticRecoveryEnabled = true` flag 

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [x] All tests passed locally.
- [ ] [Documentation comments](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/documentation-comments) included/updated.
