### PR TITLE
Use custom logging dictionary to serialize logging scope variables

### DIFF
--- a/src/Messaging/Common/LoggingDataDictionary.cs
+++ b/src/Messaging/Common/LoggingDataDictionary.cs
@@ -1,0 +1,39 @@
+﻿/*
+ * Copyright 2022 MONAI Consortium
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.Globalization;
+using System.Runtime.Serialization;
+
+namespace Monai.Deploy.Messaging.Common
+{
+    [Serializable]
+    public class LoggingDataDictionary<TKey, TValue> : Dictionary<TKey, TValue> where TKey : notnull
+    {
+        public LoggingDataDictionary()
+        {
+        }
+
+        protected LoggingDataDictionary(SerializationInfo info, StreamingContext context) : base(info, context)
+        {
+        }
+
+        public override string ToString()
+        {
+            var pairs = this.Select(x => string.Format(CultureInfo.InvariantCulture, "{0}={1}", x.Key, x.Value));
+            return string.Join(", ", pairs);
+        }
+    }
+}

--- a/src/Plugins/RabbitMQ/Publisher/RabbitMqMessagePublisherService.cs
+++ b/src/Plugins/RabbitMQ/Publisher/RabbitMqMessagePublisherService.cs
@@ -21,6 +21,7 @@ using Ardalis.GuardClauses;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Monai.Deploy.Messaging.API;
+using Monai.Deploy.Messaging.Common;
 using Monai.Deploy.Messaging.Configuration;
 using Monai.Deploy.Messaging.Messages;
 using RabbitMQ.Client;
@@ -98,7 +99,7 @@ namespace Monai.Deploy.Messaging.RabbitMQ
             Guard.Against.NullOrWhiteSpace(topic);
             Guard.Against.Null(message);
 
-            using var loggingScope = _logger.BeginScope(new Dictionary<string, object>
+            using var loggingScope = _logger.BeginScope(new LoggingDataDictionary<string, object>
             {
                 ["MessageId"] = message.MessageId,
                 ["ApplicationId"] = message.ApplicationId,

--- a/src/Plugins/RabbitMQ/Subscriber/RabbitMqMessageSubscriberService.cs
+++ b/src/Plugins/RabbitMQ/Subscriber/RabbitMqMessageSubscriberService.cs
@@ -189,7 +189,7 @@ namespace Monai.Deploy.Messaging.RabbitMQ
             var consumer = new EventingBasicConsumer(_channel);
             consumer.Received += (model, eventArgs) =>
             {
-                using var loggingScope = _logger.BeginScope(new Dictionary<string, object>
+                using var loggingScope = _logger.BeginScope(new LoggingDataDictionary<string, object>
                 {
                     ["MessageId"] = eventArgs.BasicProperties.MessageId,
                     ["ApplicationId"] = eventArgs.BasicProperties.AppId,
@@ -253,7 +253,7 @@ namespace Monai.Deploy.Messaging.RabbitMQ
             var consumer = new EventingBasicConsumer(_channel);
             consumer.Received += async (model, eventArgs) =>
             {
-                using var loggingScope = _logger.BeginScope(new Dictionary<string, object>
+                using var loggingScope = _logger.BeginScope(new LoggingDataDictionary<string, object>
                 {
                     ["MessageId"] = eventArgs.BasicProperties.MessageId,
                     ["ApplicationId"] = eventArgs.BasicProperties.AppId,
@@ -302,7 +302,7 @@ namespace Monai.Deploy.Messaging.RabbitMQ
             _channel!.BasicAck(ulong.Parse(message.DeliveryTag, CultureInfo.InvariantCulture), multiple: false);
             var eventDuration = (DateTime.UtcNow - message.CreationDateTime).TotalMilliseconds;
 
-            using var loggingScope = _logger.BeginScope(new Dictionary<string, object>
+            using var loggingScope = _logger.BeginScope(new LoggingDataDictionary<string, object>
             {
                 ["EventDuration"] = eventDuration
             });


### PR DESCRIPTION

### Description

Fix issue where logging scope variable are included in the logs as data types

E.g.,
```
2022-11-15 17:39:16.0397|10002|INFO|Monai.Deploy.Messaging.RabbitMQ.RabbitMQMessageSubscriberService|System.Collections.Generic.Dictionary`2[System.String,System.Object]|Message received from queue md.workflow.request for md.workflow.request. 
```


### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] All tests passed locally.
- [ ] [Documentation comments](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/documentation-comments) included/updated.
