### PR TITLE
add PartialFail status to the task execution status

### DIFF
--- a/src/Messaging/Events/TaskExecutionStatus.cs
+++ b/src/Messaging/Events/TaskExecutionStatus.cs
@@ -23,6 +23,7 @@ namespace Monai.Deploy.Messaging.Events
         Accepted,
         Succeeded,
         Failed,
+        PartialFail,
         Canceled
     }
 }


### PR DESCRIPTION
Signed-off-by: Sam Rooke <sam.rooke@answerdigital.com>

### Description

Fixes # .

Added a new status, `PartialFail`, to the TaskExecutionStatus file for clinical review tasks.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] All tests passed locally.
