### PR TITLE
downgrade system.io.abstractions back to 17.2.3

### DIFF
--- a/doc/dependency_decisions.yml
+++ b/doc/dependency_decisions.yml
@@ -407,26 +407,19 @@
     - 4.3.0
     :when: 2022-08-16 21:39:59.280855676 Z
 - - :approve
-  - TestableIO.System.IO.Abstractions
-  - :who: mocsharp
+  - System.IO.Abstractions
+  - :who: samrooke
     :why: MIT (https://github.com/TestableIO/System.IO.Abstractions/raw/main/LICENSE)
     :versions:
-    - 18.0.1
-    :when: 2022-08-16 21:39:59.728481602 Z
+    - 17.2.3
+    :when: 2022-12-14 12:28:00.728481602 Z
 - - :approve
-  - TestableIO.System.IO.Abstractions.TestingHelpers
-  - :who: mocsharp
+  - System.IO.Abstractions.TestingHelpers
+  - :who: samrooke
     :why: MIT (https://github.com/TestableIO/System.IO.Abstractions/raw/main/LICENSE)
     :versions:
-    - 18.0.1
-    :when: 2022-08-16 21:40:00.150566731 Z
-- - :approve
-  - TestableIO.System.IO.Abstractions.Wrappers
-  - :who: mocsharp
-    :why: MIT (https://github.com/TestableIO/System.IO.Abstractions/raw/main/LICENSE)
-    :versions:
-    - 18.0.1
-    :when: 2022-11-30 21:40:00.150566731 Z
+    - 17.2.3
+    :when: 2022-12-14 12:28:00.728481602 Z
 - - :approve
   - System.IO.Compression
   - :who: mocsharp

--- a/src/Messaging/Monai.Deploy.Messaging.csproj
+++ b/src/Messaging/Monai.Deploy.Messaging.csproj
@@ -1,4 +1,4 @@
-<!--
+﻿<!--
   ~ Copyright 2021-2022 MONAI Consortium
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
@@ -80,7 +80,6 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
-    <PackageReference Include="TestableIO.System.IO.Abstractions" Version="18.0.1" />
-    <PackageReference Include="TestableIO.System.IO.Abstractions.Wrappers" Version="18.0.1" />
+    <PackageReference Include="System.IO.Abstractions" Version="17.2.3" />
   </ItemGroup>
 </Project>

--- a/src/Messaging/Tests/Monai.Deploy.Messaging.Tests.csproj
+++ b/src/Messaging/Tests/Monai.Deploy.Messaging.Tests.csproj
@@ -1,4 +1,4 @@
-<!--
+﻿<!--
   ~ Copyright 2022 MONAI Consortium
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
@@ -34,7 +34,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
     <PackageReference Include="Moq" Version="4.18.2" />
-    <PackageReference Include="TestableIO.System.IO.Abstractions.TestingHelpers" Version="18.0.1" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -44,6 +43,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="17.2.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Plugins/RabbitMQ/Tests/Monai.Deploy.Messaging.RabbitMQ.Tests.csproj
+++ b/src/Plugins/RabbitMQ/Tests/Monai.Deploy.Messaging.RabbitMQ.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<!--
+<!--
   ~ Copyright 2022 MONAI Consortium
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
@@ -38,6 +38,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="17.2.3" />
     <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="6.0.11" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.1" />
@@ -45,7 +46,6 @@
     <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
     <PackageReference Include="Moq" Version="4.18.2" />
-    <PackageReference Include="TestableIO.System.IO.Abstractions.TestingHelpers" Version="18.0.1" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/third-party-licenses.md
+++ b/third-party-licenses.md
@@ -5165,15 +5165,15 @@ consequential or other damages.
 
 
 <details>
-<summary>TestableIO.System.IO.Abstractions 18.0.1</summary>
+<summary>System.IO.Abstractions 17.2.3</summary>
 
 ## TestableIO.System.IO.Abstractions
 
-- Version: 18.0.1
+- Version: 17.2.3
 - Authors: Tatham Oddie & friends
-- Project URL: https://github.com/TestableIO/TestableIO.System.IO.Abstractions
-- Source: [NuGet](https://www.nuget.org/packages/TestableIO.System.IO.Abstractions/18.0.1)
-- License: [MIT](https://github.com/TestableIO/TestableIO.System.IO.Abstractions/raw/main/LICENSE)
+- Project URL: https://github.com/TestableIO/System.IO.Abstractions
+- Source: [NuGet](https://www.nuget.org/packages/System.IO.Abstractions/17.2.3)
+- License: [MIT](https://github.com/TestableIO/System.IO.Abstractions/raw/main/LICENSE)
 
 
 ```
@@ -5206,15 +5206,15 @@ SOFTWARE.
 
 
 <details>
-<summary>TestableIO.System.IO.Abstractions.TestingHelpers 18.0.1</summary>
+<summary>System.IO.Abstractions.TestingHelpers 17.2.3</summary>
 
-## TestableIO.System.IO.Abstractions.TestingHelpers
+## System.IO.Abstractions.TestingHelpers
 
-- Version: 18.0.1
+- Version: 17.2.3
 - Authors: Tatham Oddie & friends
-- Project URL: https://github.com/TestableIO/TestableIO.System.IO.Abstractions
-- Source: [NuGet](https://www.nuget.org/packages/TestableIO.System.IO.Abstractions.TestingHelpers/18.0.1)
-- License: [MIT](https://github.com/TestableIO/TestableIO.System.IO.Abstractions/raw/main/LICENSE)
+- Project URL: https://github.com/TestableIO/System.IO.Abstractions
+- Source: [NuGet](https://www.nuget.org/packages/System.IO.Abstractions.TestingHelpers/17.2.3)
+- License: [MIT](https://github.com/TestableIO/System.IO.Abstractions/raw/main/LICENSE)
 
 
 ```


### PR DESCRIPTION
Signed-off-by: Sam Rooke <sam.rooke@answerdigital.com>

### Description

Fixes # .

Downgrading the `System.IO.Abstractions` package to prevent conflicting versions specified in MWM

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] All tests passed locally.
