### PR TITLE
Added exception handling for unavailable previously created dead-letter queues

### DIFF
--- a/src/Plugins/RabbitMQ/Logger.cs
+++ b/src/Plugins/RabbitMQ/Logger.cs
@@ -79,5 +79,8 @@ namespace Monai.Deploy.Messaging.RabbitMQ
 
         [LoggerMessage(EventId = 10018, Level = LogLevel.Warning, Message = "Detected RabbitMQ connection shutdown due to application request. Will not attempt to reconnect. Reason: {reason}.")]
         public static partial void DetectedChannelShutdownDueToApplicationEvent(this ILogger logger, string reason);
+
+        [LoggerMessage(EventId = 10018, Level = LogLevel.Error, Message = "Detected RabbitMQ Node down or inaccessible when trying to subscribe to existing dead-letter queue {queue}")]
+        public static partial void DetectedInaccessibleNodeThatHousesDeadLetterQueue(this ILogger logger, string queue);
     }
 }


### PR DESCRIPTION
Added exception handling for previously created dead-letter queue, which prevents app startup if a RabbitMQ node is down temporarily.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [x] All tests passed locally.
- [ ] [Documentation comments](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/documentation-comments) included/updated.
