### PR TITLE
added export request to export complete message event

### DIFF
--- a/src/Messaging/Events/ExportCompleteEvent.cs
+++ b/src/Messaging/Events/ExportCompleteEvent.cs
@@ -16,6 +16,7 @@
 
 using System.ComponentModel.DataAnnotations;
 using Ardalis.GuardClauses;
+using Monai.Deploy.Messaging.Common;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 
@@ -56,6 +57,15 @@ namespace Monai.Deploy.Messaging.Events
         /// </summary>
         [JsonProperty(PropertyName = "file_statuses")]
         public Dictionary<string, FileExportStatus> FileStatuses { get; set; }
+
+        /// <summary>
+        /// Gets or set the ExportRequest type.
+        /// For standard exports this will be ExportRequestType.None
+        /// but for exports to external apps this will be ExportRequestType.ExternalProcessing
+        /// </summary>
+        [JsonProperty(PropertyName = "export_request")]
+        [Required]
+        public ExportRequestType ExportRequest { get; set; } = default!;
 
         [JsonConstructor]
         public ExportCompleteEvent()


### PR DESCRIPTION
Added field to export complete message, so we know if its a standard export or an external app request

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] All tests passed locally.
- [ ] [Documentation comments](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/documentation-comments) included/updated.
